### PR TITLE
Rewrite

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -27,7 +27,7 @@ end)
 ---- ROTATE LOGIC ----
 do
 local function rotate(loco)
-  log("DEBUG: rotating "..tostring(loco.backer_name) )
+  -- log("DEBUG: rotating "..tostring(loco.backer_name) )
   local disconnected_back = loco.disconnect_rolling_stock(defines.rail_direction.back)
   local disconnected_front = loco.disconnect_rolling_stock(defines.rail_direction.front)
   loco.rotate()
@@ -117,34 +117,8 @@ end
 
 ---- TRAIN STATE CHANGED ----
 do
-
-local train_state_definitions = {
-  [0] = "on_the_path", -- Normal state -- following the path.",
-  [1] = "path_lost", -- Had path and lost it -- must stop.",
-  [2] = "no_schedule", -- Doesn't have anywhere to go.",
-  [3] = "no_path", -- Has no path and is stopped.",
-  [4] = "arrive_signal", -- Braking before a rail signal.",
-  [5] = "wait_signal", --	Waiting at a signal.",
-  [6] = "arrive_station", --	Braking before a station.",
-  [7] = "wait_station", --	Waiting at a station.",
-  [8] = "manual_control_stop", --	Switched to manual control and has to stop.",
-  [9] = "manual_control", --	Can move if user explicitly sits in and rides the train.",
-}
-
-function GetMainLocomotive(train)
-  if train.valid and train.locomotives and (#train.locomotives.front_movers > 0 or #train.locomotives.back_movers > 0) then
-    return train.locomotives.front_movers and train.locomotives.front_movers[1] or train.locomotives.back_movers[1]
-  end
-end
-
-function GetTrainName(train)
-  local loco = GetMainLocomotive(train)
-  return loco and loco.backer_name
-end
-
 function OnTrainStateChanged(event)
   local train = event.train
-  -- log("(OnTrainStateChanged) Train name: "..tostring(GetTrainName(train))..", train.id:"..tostring(train.id).." stop: "..tostring(train.station and train.station.backer_name)..", state: "..tostring(train_state_definitions[event.old_state]).." > "..tostring(train_state_definitions[train.state])..", train.manual_mode: "..tostring(train.manual_mode) )
   if train.state == defines.train_state.wait_station or (train.manual_mode and event.old_state <= 8) then -- wait or automatic > manual
     -- players can hop into waiting trains, switch to manual and start driving
     -- without clearing global.trains_to_rotate nth_rick would incorrectly rotate shortly afterwards
@@ -152,7 +126,7 @@ function OnTrainStateChanged(event)
     if not next(global.trains_to_rotate) then
       script.on_nth_tick(nil)
     end
-    
+
     UnrotateTrain(train)
 
   elseif not train.manual_mode and (event.old_state == defines.train_state.wait_station or event.old_state == defines.train_state.manual_control) then -- wait > automatic or manual > automatic
@@ -163,11 +137,6 @@ function OnTrainStateChanged(event)
     end
   end
 end
-
-
--- function OnTrainCreated(event)
-  -- log("(OnTrainCreated) Train name: "..tostring(GetTrainName(event.train))..", train.id:"..tostring(event.train.id)..", .old_train_id_1:"..tostring(event.old_train_id_1)..", .old_train_id_2:"..tostring(event.old_train_id_2)..", state: "..tostring(train_state_definitions[event.train.state]))
--- end
 
 end
 
@@ -182,7 +151,7 @@ function OnNthTick(NthTickEvent)
     else
       -- remove invalid train
       global.trains_to_rotate[trainID] = nil
-      log("DEBUG: removed invalid train "..trainID)
+      -- log("DEBUG: removed invalid train "..trainID)
     end
   end
 
@@ -196,7 +165,6 @@ end
 do
 local function init_events()
   script.on_event(defines.events.on_train_changed_state, OnTrainStateChanged)
-  -- script.on_event(defines.events.on_train_created, OnTrainCreated)
   if next(global.trains_to_rotate) then
     script.on_nth_tick(Nth_tick, OnNthTick)
   end

--- a/control.lua
+++ b/control.lua
@@ -5,15 +5,18 @@ local Nth_tick = settings.global["Noxys_Multidirectional_Trains-on_nth_tick"].va
 script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
   if event.setting == "Noxys_Multidirectional_Trains-enabled" then
     Enabled = settings.global["Noxys_Multidirectional_Trains-enabled"].value
-    if not Enabled then
-			-- revert rotated trains
+    if Enabled then      
+      script.on_event(defines.events.on_train_changed_state, OnTrainStateChanged)
+    else
+      script.on_event(defines.events.on_train_changed_state, nil)
+      -- revert rotated trains
       for _, surface in pairs(game.surfaces) do
         local trains = surface.get_trains()
         for _,train in pairs(trains) do
           UnrotateTrain(train)
         end
-      end
-		end
+      end		    
+    end
   end
   if event.setting == "Noxys_Multidirectional_Trains-on_nth_tick" then
     Nth_tick = settings.global["Noxys_Multidirectional_Trains-on_nth_tick"].value
@@ -145,7 +148,11 @@ end
 ---- INIT ----
 do
 local function init_events()
-  script.on_event(defines.events.on_train_changed_state, OnTrainStateChanged)
+  if Enabled then      
+    script.on_event(defines.events.on_train_changed_state, OnTrainStateChanged)
+  else
+    script.on_event(defines.events.on_train_changed_state, nil)
+  end
   if next(global.trains_to_rotate) then
     script.on_nth_tick(Nth_tick, OnNthTick)
   end

--- a/control.lua
+++ b/control.lua
@@ -1,111 +1,223 @@
+---- MOD SETTINGS ----
+local Enabled = settings.global["Noxys_Multidirectional_Trains-enabled"].value
+local Nth_tick = settings.global["Noxys_Multidirectional_Trains-on_nth_tick"].value
+
+script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
+  if event.setting == "Noxys_Multidirectional_Trains-enabled" then
+    Enabled = settings.global["Noxys_Multidirectional_Trains-enabled"].value
+    if not Enabled then
+			-- revert rotated trains
+      for _, surface in pairs(game.surfaces) do
+        local trains = surface.get_trains()
+        for _,train in pairs(trains) do
+          UnrotateTrain(train)
+        end
+      end
+		end
+  end
+  if event.setting == "Noxys_Multidirectional_Trains-on_nth_tick" then
+    Nth_tick = settings.global["Noxys_Multidirectional_Trains-on_nth_tick"].value
+    script.on_nth_tick(nil)
+    if next(global.trains_to_rotate) then
+      script.on_nth_tick(Nth_tick, OnNthTick)
+    end
+  end
+end)
+
+---- ROTATE LOGIC ----
+do
 local function rotate(loco)
-	-- @todo: This is a hack since you can't rotate stock when it is connected.
-	loco.disconnect_rolling_stock(defines.rail_direction.back)
-	loco.disconnect_rolling_stock(defines.rail_direction.front)
-	loco.rotate()
-	-- Try to reconnect
-	loco.connect_rolling_stock(defines.rail_direction.back)
-	loco.connect_rolling_stock(defines.rail_direction.front)
+  log("DEBUG: rotating "..tostring(loco.backer_name) )
+  local disconnected_back = loco.disconnect_rolling_stock(defines.rail_direction.back)
+  local disconnected_front = loco.disconnect_rolling_stock(defines.rail_direction.front)
+  loco.rotate()
+  -- Only reconnect the side that was disconnected
+  local reconnected_front = disconnected_front
+  local reconnected_back = disconnected_back
+  if disconnected_back then
+    reconnected_back = loco.connect_rolling_stock(defines.rail_direction.front)
+  end
+  if disconnected_front then
+    reconnected_front= loco.connect_rolling_stock(defines.rail_direction.back)
+  end
+  -- TODO: reconnect Error handling
+  if disconnected_front and not reconnected_front then
+    log("Error: Failed to reconnect front.")
+  end
+  if disconnected_back and not reconnected_back then
+    log("Error: Failed to reconnect back.")
+  end
 end
+
+-- rotate all locomotives to face driving direction
+-- rotated locomotives are added to global.rotated_locos
+function RotateTrain(train)
+  local rotate_locos = {}
+  local manual_mode = train.manual_mode
+  -- train becomes invalid when rotating carriages
+  -- collect locos to rotate
+
+  if manual_mode then return end -- never rotate manual mode trains
+
+  for _, movers in pairs(train.locomotives) do
+    for _, loco in pairs(movers) do
+      if not global.rotated_locos[loco.unit_number] and loco.speed < 0 then
+        -- rotate_locos[#rotate_locos+1] = loco
+        global.rotated_locos[loco.unit_number] = true
+        rotate(loco)
+        train = loco.train -- changing the reference of the iterated list seems like a bad idea
+      end
+    end
+  end
+
+  -- do rotation without worrying about invalidating the train
+  -- for _, loco in pairs(rotate_locos) do
+    -- global.rotated_locos[loco.unit_number] = true
+    -- rotate(loco)
+    -- train = loco.train
+  -- end
+
+  -- setting train back to previous mode without check causes train to bounce between states
+  if train.manual_mode ~= manual_mode then
+    train.manual_mode = manual_mode
+  end
+end
+
+-- rotate locomotives listed in global.rotated_locos
+function UnrotateTrain(train)
+  local rotate_locos = {}
+  local manual_mode = train.manual_mode
+  -- train becomes invalid when rotating carriages
+  -- collect locos to rotate
+  for _, movers in pairs(train.locomotives) do
+    for _, loco in pairs(movers) do
+      if global.rotated_locos[loco.unit_number] then
+        -- rotate_locos[#rotate_locos+1] = loco
+        rotate(loco)
+        global.rotated_locos[loco.unit_number] = nil
+        train = loco.train -- changing the reference of the iterated list seems like a bad idea
+      end
+    end
+  end
+
+  -- do rotation without worrying about invalidating the train
+  -- for _, loco in pairs(rotate_locos) do
+    -- rotate(loco)
+    -- global.rotated_locos[loco.unit_number] = nil
+    -- train = loco.train
+  -- end
+
+  -- setting train back to previous mode without check causes train to bounce between states
+  if train.manual_mode ~= manual_mode then
+    train.manual_mode = manual_mode
+  end
+end
+
+end
+
+---- TRAIN STATE CHANGED ----
+do
+
+local train_state_definitions = {
+  [0] = "on_the_path", -- Normal state -- following the path.",
+  [1] = "path_lost", -- Had path and lost it -- must stop.",
+  [2] = "no_schedule", -- Doesn't have anywhere to go.",
+  [3] = "no_path", -- Has no path and is stopped.",
+  [4] = "arrive_signal", -- Braking before a rail signal.",
+  [5] = "wait_signal", --	Waiting at a signal.",
+  [6] = "arrive_station", --	Braking before a station.",
+  [7] = "wait_station", --	Waiting at a station.",
+  [8] = "manual_control_stop", --	Switched to manual control and has to stop.",
+  [9] = "manual_control", --	Can move if user explicitly sits in and rides the train.",
+}
+
+function GetMainLocomotive(train)
+  if train.valid and train.locomotives and (#train.locomotives.front_movers > 0 or #train.locomotives.back_movers > 0) then
+    return train.locomotives.front_movers and train.locomotives.front_movers[1] or train.locomotives.back_movers[1]
+  end
+end
+
+function GetTrainName(train)
+  local loco = GetMainLocomotive(train)
+  return loco and loco.backer_name
+end
+
+function OnTrainStateChanged(event)
+  local train = event.train
+  -- log("(OnTrainStateChanged) Train name: "..tostring(GetTrainName(train))..", train.id:"..tostring(train.id).." stop: "..tostring(train.station and train.station.backer_name)..", state: "..tostring(train_state_definitions[event.old_state]).." > "..tostring(train_state_definitions[train.state])..", train.manual_mode: "..tostring(train.manual_mode) )
+  if train.state == defines.train_state.wait_station or (train.manual_mode and event.old_state <= 8) then -- wait or automatic > manual
+    -- players can hop into waiting trains, switch to manual and start driving
+    -- without clearing global.trains_to_rotate nth_rick would incorrectly rotate shortly afterwards
+    global.trains_to_rotate[train.id] = nil
+    if not next(global.trains_to_rotate) then
+      script.on_nth_tick(nil)
+    end
+    
+    UnrotateTrain(train)
+
+  elseif not train.manual_mode and (event.old_state == defines.train_state.wait_station or event.old_state == defines.train_state.manual_control) then -- wait > automatic or manual > automatic
+    -- train left station > check multi loco train in n ticks for rotation
+    if (#train.locomotives.front_movers + #train.locomotives.back_movers) > 1 then
+      global.trains_to_rotate[train.id] = train
+      script.on_nth_tick(Nth_tick, OnNthTick)
+    end
+  end
+end
+
+
+-- function OnTrainCreated(event)
+  -- log("(OnTrainCreated) Train name: "..tostring(GetTrainName(event.train))..", train.id:"..tostring(event.train.id)..", .old_train_id_1:"..tostring(event.old_train_id_1)..", .old_train_id_2:"..tostring(event.old_train_id_2)..", state: "..tostring(train_state_definitions[event.train.state]))
+-- end
+
+end
+
+-- dirty hack to get locomotive orientation through speed some ticks after it started moving
+function OnNthTick(NthTickEvent)
+  for trainID, train in pairs(global.trains_to_rotate) do
+    if train.valid then
+      if train.speed ~= 0 then
+        RotateTrain(train)
+        global.trains_to_rotate[trainID] = nil
+      end
+    else
+      -- remove invalid train
+      global.trains_to_rotate[trainID] = nil
+      log("DEBUG: removed invalid train "..trainID)
+    end
+  end
+
+  -- unsubscribe once all trains are rotated
+  if not next(global.trains_to_rotate) then
+    script.on_nth_tick(nil)
+  end
+end
+
+---- INIT ----
+do
+local function init_events()
+  script.on_event(defines.events.on_train_changed_state, OnTrainStateChanged)
+  -- script.on_event(defines.events.on_train_created, OnTrainCreated)
+  if next(global.trains_to_rotate) then
+    script.on_nth_tick(Nth_tick, OnNthTick)
+  end
+end
+
+script.on_load(function()
+  init_events()
+end)
 
 script.on_init(function()
-	global.movingstate = {}
+  global.rotated_locos = global.rotated_locos or {}
+  global.trains_to_rotate = global.trains_to_rotate or {}
+  init_events()
 end)
 
-script.on_event(defines.events.on_train_created, function (event)
-	if event.old_train_id_1 then -- We can ignore old_train_id_2 since the first old id is the one that gets its stuff copied.
-		-- Train changed
-		global.movingstate[event.train.id] = global.movingstate[event.old_train_id_1]
-		global.movingstate[event.old_train_id_1] = nil
-	else
-		-- Train created
-		global.movingstate[event.train.id] = false
-	end
+script.on_configuration_changed(function(data)
+  global.rotated_locos = global.rotated_locos or {}
+  global.trains_to_rotate = global.trains_to_rotate or {}
+  init_events()
 end)
 
-local config = {}
-
-local function cache_settings()
-	config.enabled     = settings.global["Noxys_Multidirectional_Trains-enabled"].value
-	config.on_nth_tick = settings.global["Noxys_Multidirectional_Trains-on_nth_tick"].value
 end
 
-cache_settings()
 
-local function train_rotate(train)
-	local rotated = false
-	local manual_mode = train.manual_mode
-	for _,locos in pairs(train.locomotives) do
-		for _,loco in pairs(locos) do
-			if loco.speed < 0 then
-				if not global[loco.unit_number] then -- prevent double rotates
-					global[loco.unit_number] = true
-					rotate(loco)
-					rotated = true
-					train = loco.train
-				end
-			end
-		end
-	end
-	if rotated then
-		train.manual_mode = manual_mode
-	end
-end
-
-local function train_unrotate(train)
-	local rotated = false
-	local manual_mode = train.manual_mode
-	for _, locos in pairs(train.locomotives) do
-		for _, loco in pairs(locos) do
-			if global[loco.unit_number] then
-				rotate(loco)
-				rotated = true
-				global[loco.unit_number] = nil
-				train = loco.train
-			end
-		end
-	end
-	if rotated then
-		train.manual_mode = manual_mode
-	end
-end
-
-local function update_settings(event)
-	if event.setting == "Noxys_Multidirectional_Trains-enabled" then
-		config.enabled     = settings.global["Noxys_Multidirectional_Trains-enabled"].value
-		if config.enabled == false then
-			-- revert rotated trains
-			local trains = game.surfaces[1].get_trains()
-			for _,train in pairs(trains) do
-				train_unrotate(train)
-			end
-		end
-	end
-	if event.setting == "Noxys_Multidirectional_Trains-on_nth_tick" then
-		config.on_nth_tick = settings.global["Noxys_Multidirectional_Trains-on_nth_tick"].value
-	end
-end
-
-script.on_event({defines.events.on_runtime_mod_setting_changed}, update_settings)
-
-script.on_event(defines.events.on_tick, function(event)
-	if not config.enabled then return end
-	if event.tick % config.on_nth_tick ~= 0 then return end
-	local trains = game.surfaces[1].get_trains()
-	for _,train in pairs(trains) do
-		if not train or not train.valid then return end
-		local id = train.id
-		local moving = train.speed ~= 0
-		if moving ~= global.movingstate[id] then
-			local global = global
-			global.movingstate[id] = moving
-			if moving then -- Started moving: figure out which locos are facing the wrong way.
-				if not train.manual_mode then
-					train_rotate(train)
-				end
-			else -- No longer moving. Revert the train to its neutral state.
-				train_unrotate(train)
-			end
-		end
-	end
-end)

--- a/control.lua
+++ b/control.lua
@@ -9,15 +9,20 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
       script.on_event(defines.events.on_train_changed_state, OnTrainStateChanged)
     else
       script.on_event(defines.events.on_train_changed_state, nil)
+      script.on_nth_tick(nil)
       -- revert rotated trains
       for _, surface in pairs(game.surfaces) do
         local trains = surface.get_trains()
         for _,train in pairs(trains) do
           UnrotateTrain(train)
         end
-      end		    
+      end
+      -- clean globals
+      global.rotated_locos = {}
+      global.trains_to_rotate = {}
     end
   end
+  
   if event.setting == "Noxys_Multidirectional_Trains-on_nth_tick" then
     Nth_tick = settings.global["Noxys_Multidirectional_Trains-on_nth_tick"].value
     script.on_nth_tick(nil)

--- a/control.lua
+++ b/control.lua
@@ -52,30 +52,21 @@ end
 -- rotate all locomotives to face driving direction
 -- rotated locomotives are added to global.rotated_locos
 function RotateTrain(train)
-  local rotate_locos = {}
   local manual_mode = train.manual_mode
-  -- train becomes invalid when rotating carriages
-  -- collect locos to rotate
 
   if manual_mode then return end -- never rotate manual mode trains
 
+  -- train becomes invalid when rotating carriages, updating to loco.train inside the loops allows working with the updated reference
   for _, movers in pairs(train.locomotives) do
     for _, loco in pairs(movers) do
       if not global.rotated_locos[loco.unit_number] and loco.speed < 0 then
         -- rotate_locos[#rotate_locos+1] = loco
         global.rotated_locos[loco.unit_number] = true
         rotate(loco)
-        train = loco.train -- changing the reference of the iterated list seems like a bad idea
+        train = loco.train
       end
     end
   end
-
-  -- do rotation without worrying about invalidating the train
-  -- for _, loco in pairs(rotate_locos) do
-    -- global.rotated_locos[loco.unit_number] = true
-    -- rotate(loco)
-    -- train = loco.train
-  -- end
 
   -- setting train back to previous mode without check causes train to bounce between states
   if train.manual_mode ~= manual_mode then
@@ -85,27 +76,17 @@ end
 
 -- rotate locomotives listed in global.rotated_locos
 function UnrotateTrain(train)
-  local rotate_locos = {}
   local manual_mode = train.manual_mode
-  -- train becomes invalid when rotating carriages
-  -- collect locos to rotate
+  -- train becomes invalid when rotating carriages, updating to loco.train inside the loops allows working with the updated reference
   for _, movers in pairs(train.locomotives) do
     for _, loco in pairs(movers) do
       if global.rotated_locos[loco.unit_number] then
-        -- rotate_locos[#rotate_locos+1] = loco
         rotate(loco)
         global.rotated_locos[loco.unit_number] = nil
-        train = loco.train -- changing the reference of the iterated list seems like a bad idea
+        train = loco.train
       end
     end
   end
-
-  -- do rotation without worrying about invalidating the train
-  -- for _, loco in pairs(rotate_locos) do
-    -- rotate(loco)
-    -- global.rotated_locos[loco.unit_number] = nil
-    -- train = loco.train
-  -- end
 
   -- setting train back to previous mode without check causes train to bounce between states
   if train.manual_mode ~= manual_mode then

--- a/info.json
+++ b/info.json
@@ -1,11 +1,11 @@
 {
   "name": "Noxys_Multidirectional_Trains",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "factorio_version": "0.16",
   "title": "Noxys Multidirectional Trains",
   "author": "Noxy",
   "contact": "donotcontactme@example.com",
   "homepage": "https://mods.factorio.com/",
   "description": "Sneakily rotate locomotives that are being pulled backwards so that they actually help with acceleration instead of just being dead weight.",
-  "dependencies": ["base >= 0.16.27"]
+  "dependencies": ["base >= 0.16.51"]
 }

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Noxys_Multidirectional_Trains",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "factorio_version": "0.16",
   "title": "Noxys Multidirectional Trains",
   "author": "Noxy",

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -3,5 +3,5 @@ Noxys_Multidirectional_Trains-on_nth_tick=On nth tick
 Noxys_Multidirectional_Trains-enabled=Enabled
 
 [mod-setting-description]
-Noxys_Multidirectional_Trains-on_nth_tick=Delay between leaving station and speed measurment for rotation.
+Noxys_Multidirectional_Trains-on_nth_tick=Delay between leaving station and speed measurment for rotation. Has no effect on performance.
 Noxys_Multidirectional_Trains-enabled=Enables train rotation. Set this to off if you want to remove this mod and have all your trains rotated back.

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -3,5 +3,5 @@ Noxys_Multidirectional_Trains-on_nth_tick=On nth tick
 Noxys_Multidirectional_Trains-enabled=Enabled
 
 [mod-setting-description]
-Noxys_Deep_Core_Mining_Tweak-multiplier=Check locomotives that need rotation every nth tick (Smaller numbers means fastr updates).
+Noxys_Multidirectional_Trains-on_nth_tick=Delay between leaving station and speed measurment for rotation.
 Noxys_Multidirectional_Trains-enabled=Enables train rotation. Set this to off if you want to remove this mod and have all your trains rotated back.


### PR DESCRIPTION
- fixed trains coupling with another #7 
- trains only rotate when leaving and entering stations or are toggled between manual and automatic
- uses only on_train_state_changed instead of on_tick polling
- plays nice with other mods using on_train_state_changed like LTN #2 