### PR TITLE
Add events for tracking rotation and exposing train id changes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,4 +2,6 @@
 Version: 0.5.3
 Date: ????
   Features:
-    - Added remote interface with events for train rotating, unrotating, and for each locomotive rotated.
+    - Added remote interface with events for train rotating, unrotating, and for each locomotive rotated
+  Bugfixes:
+    - Fixed crash in the event a train is rotated without a schedule

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,5 @@
+---------------------------------------------------------------------------------------------------
+Version: 0.5.3
+Date: ????
+  Features:
+    - Added remote interface with events for train rotating, unrotating, and for each locomotive rotated.

--- a/control.lua
+++ b/control.lua
@@ -1,8 +1,14 @@
+require("scripts.remote-interface")
+
 local settings_enabled = settings.global["Noxys_Multidirectional_Trains-enabled"].value
 local settings_nth_tick = settings.global["Noxys_Multidirectional_Trains-on_nth_tick"].value
 local settings_station_limits = settings.global["Noxys_Multidirectional_Trains-station_limits"].value
 
+---Rotates the given locomotive.
+---@param loco LuaEntity
 local function rotate(loco)
+  local old_train_id = loco.train and loco.train.id
+
   -- todo: This is a hack since you can't rotate stock when it is connected.
   local disconnected_back = loco.disconnect_rolling_stock(defines.rail_direction.back)
   local disconnected_front = loco.disconnect_rolling_stock(defines.rail_direction.front)
@@ -13,32 +19,49 @@ local function rotate(loco)
   if disconnected_front then
     loco.connect_rolling_stock(defines.rail_direction.back)
   end
-  -- Error handling removed since a meaningfull error message is difficult (or too noisy) to produce.
+
+  raise_train_locomotive_rotated(loco.train, old_train_id)
+  -- Error handling removed since a meaningful error message is difficult (or too noisy) to produce.
 end
 
--- Rotate all locomotives to face driving direction, rotated locomotives are added to storage.rotated_locos.
-local function train_rotate(train)
+---Rotate all locomotives to face driving direction, rotated locomotives are added to `storage.rotated_locos`.
+---@param train LuaTrain
+---@param old_state defines.train_state?
+local function train_rotate(train, old_state)
   local schedule_index = train.schedule.current
   local manual_mode = train.manual_mode
   if manual_mode then return end -- never rotate manual mode trains
+
+  local has_raised_rotate_started_event = false
+  local old_train_id = train.id
+
   for _, locos in pairs(train.locomotives) do
     for _, loco in pairs(locos) do
+      ---@cast loco LuaEntity
       if not storage.rotated_locos[loco.unit_number] and loco.speed < 0 then -- prevent double rotates
+        if not has_raised_rotate_started_event then -- raise event only if the train is going to rotate.
+          raise_train_rotating(train, old_state)
+          has_raised_rotate_started_event = true
+        end
         storage.rotated_locos[loco.unit_number] = true
         rotate(loco)
         train = loco.train -- Ensure that this reference is valid for restoring manual mode.
       end
     end
   end
-  if train.manual_mode ~= manual_mode then
+  if train and train.manual_mode ~= manual_mode then
     train.manual_mode = manual_mode
   end
-  if schedule_index and train.valid then
+  if schedule_index and train and train.valid then
     train.go_to_station(schedule_index)
+  end
+
+  if has_raised_rotate_started_event then -- raise event only if the train was rotated.
+    raise_on_train_rotated(train, old_train_id, old_state)
   end
 end
 
--- Hack to get locomotive orientation through speed some ticks after it started moving.
+---Hack to get locomotive orientation through speed some ticks after it started moving.
 local function on_nth_tick()
   for trainID, train in pairs(storage.trains_to_rotate) do
     if train.valid then
@@ -62,7 +85,8 @@ local function on_nth_tick()
   end
 end
 
--- Revert the rotated locomotives listed in storage.rotated_locos.
+---Revert the rotated locomotives listed in `storage.rotated_locos`.
+---@param train LuaTrain
 local function train_unrotate(train)
   local schedule_index = train.schedule.current
   local manual_mode = train.manual_mode
@@ -72,20 +96,33 @@ local function train_unrotate(train)
     storage.station_limits[station.unit_number] = station
     script.on_nth_tick(settings_nth_tick, on_nth_tick)
   end
+
+  local has_raised_rotate_started_event = false
+  local old_train_id = train.id
+
   for _, locos in pairs(train.locomotives) do
     for _, loco in pairs(locos) do
+      ---@cast loco LuaEntity
       if storage.rotated_locos[loco.unit_number] then
+        if not has_raised_rotate_started_event then -- raise event only if the train is going to rotate.
+          raise_train_rotating(train)
+          has_raised_rotate_started_event = true
+        end
         rotate(loco)
         storage.rotated_locos[loco.unit_number] = nil
         train = loco.train -- Ensure that this reference is valid for restoring manual mode.
       end
     end
   end
-  if train.manual_mode ~= manual_mode then
+  if train and train.manual_mode ~= manual_mode then
     train.manual_mode = manual_mode
   end
-  if schedule_index and train.valid then
+  if schedule_index and train and train.valid then
     train.go_to_station(schedule_index)
+  end
+
+  if has_raised_rotate_started_event then -- raise event only if the train was rotated.
+    raise_on_train_rotated(train, old_train_id)
   end
 end
 
@@ -93,7 +130,6 @@ local function on_train_changed_state(event)
   local train = event.train
   if train.state == defines.train_state.wait_station or
       train.state == defines.train_state.no_path or
-      train.state == defines.train_state.path_lost or
       (train.manual_mode and event.old_state ~= defines.train_state.manual_control_stop and
         event.old_state ~= defines.train_state.manual_control)
   then
@@ -101,6 +137,9 @@ local function on_train_changed_state(event)
     if not next(storage.trains_to_rotate) and not next(storage.station_limits) then
       script.on_nth_tick(nil)
     end
+    --Raise prior to unrotating to ensure train state at time of unrotation is available to subscribers.
+    raise_train_unrotating(train, event.old_state)
+
     train_unrotate(train)
   elseif not train.manual_mode and
       (event.old_state == defines.train_state.wait_station or

--- a/control.lua
+++ b/control.lua
@@ -26,9 +26,7 @@ end
 
 ---Rotate all locomotives to face driving direction, rotated locomotives are added to `storage.rotated_locos`.
 ---@param train LuaTrain
----@param old_state defines.train_state?
-local function train_rotate(train, old_state)
-  local schedule_index = train.schedule.current
+local function train_rotate(train)
   local manual_mode = train.manual_mode
   if manual_mode then return end -- never rotate manual mode trains
 
@@ -40,7 +38,7 @@ local function train_rotate(train, old_state)
       ---@cast loco LuaEntity
       if not storage.rotated_locos[loco.unit_number] and loco.speed < 0 then -- prevent double rotates
         if not has_raised_rotate_started_event then -- raise event only if the train is going to rotate.
-          raise_train_rotating(train, old_state)
+          raise_train_rotating(train)
           has_raised_rotate_started_event = true
         end
         storage.rotated_locos[loco.unit_number] = true
@@ -57,7 +55,7 @@ local function train_rotate(train, old_state)
   end
 
   if has_raised_rotate_started_event then -- raise event only if the train was rotated.
-    raise_on_train_rotated(train, old_train_id, old_state)
+    raise_on_train_rotated(train, old_train_id)
   end
 end
 

--- a/control.lua
+++ b/control.lua
@@ -27,6 +27,7 @@ end
 ---Rotate all locomotives to face driving direction, rotated locomotives are added to `storage.rotated_locos`.
 ---@param train LuaTrain
 local function train_rotate(train)
+  local schedule_index = train.schedule and train.schedule.current
   local manual_mode = train.manual_mode
   if manual_mode then return end -- never rotate manual mode trains
 
@@ -86,7 +87,7 @@ end
 ---Revert the rotated locomotives listed in `storage.rotated_locos`.
 ---@param train LuaTrain
 local function train_unrotate(train)
-  local schedule_index = train.schedule.current
+  local schedule_index = train.schedule and train.schedule.current
   local manual_mode = train.manual_mode
   local station = train.station
   if settings_station_limits and station and station.trains_limit == 1 then

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "Noxys_Multidirectional_Trains",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"factorio_version": "2.0",
 	"title": "Noxys Multidirectional Trains",
 	"author": "Noxy",

--- a/scripts/remote-interface.lua
+++ b/scripts/remote-interface.lua
@@ -1,0 +1,83 @@
+-- NOTE: Events are only raised after a mod has called the associated "get" method.
+
+local on_train_rotating = nil
+local on_train_locomotive_rotated = nil
+local on_train_rotated = nil
+local on_train_unrotating = nil
+
+local interface = {}
+
+function interface.get_on_train_rotating()
+    if not on_train_rotating then on_train_rotating = script.generate_event_name() end
+    return on_train_rotating
+end
+function interface.get_on_train_locomotive_rotated()
+    if not on_train_locomotive_rotated then on_train_locomotive_rotated = script.generate_event_name() end
+    return on_train_locomotive_rotated
+end
+function interface.get_on_train_rotated()
+    if not on_train_rotated then on_train_rotated = script.generate_event_name() end
+    return on_train_rotated
+end
+function interface.get_on_train_unrotating()
+    if not on_train_unrotating then on_train_unrotating = script.generate_event_name() end
+    return on_train_unrotating
+end
+
+remote.add_interface("Noxys_Multidirectional_Trains", interface)
+
+---Raises the `on_train_rotating` event, if the event has been subscribed.
+---
+---This event is raised when a train has one-or-more locomotives that will be rotated, prior to rotating any locomotive.
+---@param train LuaTrain The train entity to be rotated.
+function raise_train_rotating(train)
+    if on_train_rotating then
+        script.raise_event(on_train_rotating, {
+            train = train,
+        })
+    end
+end
+
+---Raises the `on_train_locomotive_rotated` event, if the event has been subscribed.
+---
+---This event is raised for each locomotive that is rotated
+---@param train LuaTrain The new Train entity created after rotating a single locomotive.
+---@param old_train_id uint The unique ID of the train that was destroyed by rotating a single locomotive.
+function raise_train_locomotive_rotated(train, old_train_id)
+    if on_train_locomotive_rotated then
+        script.raise_event(on_train_locomotive_rotated, {
+            train = train,
+            old_train_id_1 = old_train_id,
+        })
+    end
+end
+
+---Raises the `on_train_rotated` event, if the event has been subscribed.
+---
+---This event is raised after all locomotives have been rotated.
+---@param train LuaTrain The train entity for the rotated train.
+---@param old_train_id uint The unique ID of the train prior to rotating locomotives.
+function raise_on_train_rotated(train, old_train_id)
+    if on_train_rotated then
+        script.raise_event(on_train_rotated, {
+            train = train,
+            old_train_id_1 = old_train_id,
+        })
+    end
+end
+
+---Raises the `on_train_unrotating` event, if the event has been subscribed. Shares
+---event parameters with `EventData.on_train_changed_state`.
+---
+---This event is raised during `on_train_changed_state` when a train is at a station, has no path, or is 
+---switch to manual and will be checked for locomotives to be unrotated.
+---@param train LuaTrain The train entity to be checked for locomotives to be unrotated.
+---@param old_state defines.train_state The old state of the train.
+function raise_train_unrotating(train, old_state)
+    if on_train_unrotating then
+        script.raise_event(on_train_unrotating, {
+            train = train,
+            old_state = old_state,
+        })
+    end
+end


### PR DESCRIPTION
Adds four events:
- on_train_rotating
  - Raised when a train will _actually_ rotate, prior to any rotation occurring. Raised for both rotate/unrotate actions.
- on_train_locomotive_rotated
  - Raised for each locomotive that is rotated, after the new train is created.
- on_train_rotated
  - Raised after all locomotives have rotated.
- on_train_unrotating
  - Raised prior to unrotating a train due to a change in train state. Notably, not raised prior to unrotating a train due to disabling Noxy in Map settings.

This sets up a generic way for mods to integrate compatibility with this mod, since the primary pain point is tracking train id changes and when rotations occur. 

This is part of a related pull request to integrate compatibility with Project Cybersyn. 

It's not rigorously tested...